### PR TITLE
fix: remove alias same commander

### DIFF
--- a/src/lib/TaskManager.js
+++ b/src/lib/TaskManager.js
@@ -15,7 +15,6 @@ module.exports = class TaskManager {
     this.runners.forEach(r => {
       let c = this.commander;
       c = c.command(r.command);
-      if (r.commandAlias) c.alias(r.commandAlias);
       if (r.description) c.description(r.description);
       if (r.options) {
         r.options.map(o => c.option(o[0], o[1]));


### PR DESCRIPTION
Fix the issue below: 
```bash
/usr/local/lib/node_modules/qualifys/node_modules/commander/index.js:898
  if (alias === command._name) throw new Error('Command alias can\'t be the same as its name');
                               ^

Error: Command alias can't be the same as its name
    at Command.alias (/usr/local/lib/node_modules/qualifys/node_modules/commander/index.js:898:38)
    at runners.forEach.r (/usr/local/lib/node_modules/qualifys/src/lib/TaskManager.js:18:29)
    at Array.forEach (<anonymous>)
    at TaskManager.init (/usr/local/lib/node_modules/qualifys/src/lib/TaskManager.js:15:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/qualifys/src/index.js:18:13)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
```
## link

https://github.com/tj/commander.js/blob/master/CHANGELOG.md#2120--2017-11-22